### PR TITLE
Add workaround for ipywidgets<=7.3.2

### DIFF
--- a/js/src/sheet.ts
+++ b/js/src/sheet.ts
@@ -300,8 +300,7 @@ let SheetView = widgets.DOMWidgetView.extend({
                         }
                     }
                     if (!previous_view && widget && widget.widget_manager) {
-                        widget_view_promises[idx] = widget.widget_manager.create_view(widget);
-                        // widget_view_promises[idx] = this.create_child_view(widget)
+                        widget_view_promises[idx] = this.create_child_view(widget)
                     }
                 }
             }

--- a/js/src/sheet.ts
+++ b/js/src/sheet.ts
@@ -299,8 +299,8 @@ let SheetView = widgets.DOMWidgetView.extend({
                             previous_view = null;
                         }
                     }
-                    if (!previous_view && widget && widget.widget_manager) {
-                        widget_view_promises[idx] = this.create_child_view(widget)
+                    if (!previous_view && widget) {
+                        widget_view_promises[idx] = this.create_child_view(widget);
                     }
                 }
             }

--- a/js/src/sheet.ts
+++ b/js/src/sheet.ts
@@ -281,6 +281,9 @@ let SheetView = widgets.DOMWidgetView.extend({
         }
     },
     async _build_widgets_views() {
+        // Workaround for ipywidgets < 7.4.0
+        let options = {output: {handle_output: () => {}, handle_clear_output: () => {}}};
+
         let data = this.model.data;
         let rows = data.length;
         let cols = data[0].length;
@@ -300,7 +303,7 @@ let SheetView = widgets.DOMWidgetView.extend({
                         }
                     }
                     if (!previous_view && widget && widget.widget_manager) {
-                        widget_view_promises[idx] = widget.widget_manager.create_view(widget)
+                        widget_view_promises[idx] = widget.widget_manager.create_view(widget, options);
                     }
                 }
             }

--- a/js/src/sheet.ts
+++ b/js/src/sheet.ts
@@ -281,9 +281,6 @@ let SheetView = widgets.DOMWidgetView.extend({
         }
     },
     async _build_widgets_views() {
-        // Workaround for ipywidgets < 7.4.0
-        let options = {output: {handle_output: () => {}, handle_clear_output: () => {}}};
-
         let data = this.model.data;
         let rows = data.length;
         let cols = data[0].length;
@@ -303,7 +300,8 @@ let SheetView = widgets.DOMWidgetView.extend({
                         }
                     }
                     if (!previous_view && widget && widget.widget_manager) {
-                        widget_view_promises[idx] = widget.widget_manager.create_view(widget, options);
+                        widget_view_promises[idx] = widget.widget_manager.create_view(widget);
+                        // widget_view_promises[idx] = this.create_child_view(widget)
                     }
                 }
             }

--- a/js/src/test/dummy-manager.ts
+++ b/js/src/test/dummy-manager.ts
@@ -105,6 +105,20 @@ class DummyManager extends widgets.ManagerBase<HTMLElement> {
         return Promise.resolve(new MockComm());
     }
 
+    setViewOptions(options) {
+        // mimics widgetsnbextension's manager that goes with ipywidgets<=7.3.2
+        var options = options || {};
+        if (!options.output && options.parent) {
+            // use the parent output if we don't have one
+            options.output = options.parent.options.output;
+        }
+        options.iopub_callbacks = {
+            output: options.output.handle_output.bind(options.output),
+            clear_output: options.output.handle_clear_output.bind(options.output)
+        }
+        return options;
+    }
+
     el: HTMLElement;
     library: any;
 }

--- a/js/src/test/utils.ts
+++ b/js/src/test/utils.ts
@@ -1,7 +1,7 @@
 export
 async function make_view() {
-    const options = { model: this.sheet };
-    const view = await this.manager.create_view(this.sheet); //new ipysheet.SheetView(options);
+    const options = { model: this.sheet, output: {handle_output: () => {}, handle_clear_output: () => {}}};
+    const view = await this.manager.create_view(this.sheet, options); //new ipysheet.SheetView(options);
     await this.manager.display_view(undefined, view);
     return view;
 }

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup_args = {
         ('etc/jupyter/nbconfig/notebook.d', ['ipysheet.json'])
     ],
     'install_requires': [
-        'ipywidgets>=7.4.2',
+        'ipywidgets>=7.0.0',
     ],
     'packages': find_packages(),
     'zip_safe': False,


### PR DESCRIPTION
Having a widget in a cell does not work for ipywidgets<=7.4.2

It results in this JavaScript error: `TypeError: Cannot read property 'handle_output' of undefined`.

This PR is a workaround for making it working with older versions