### PR TITLE
Add missing `install` to the jlab command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ pip install ipysheet
 
 To make it work for Jupyter lab:
 ```
-$ jupyter labextension ipysheet
+$ jupyter labextension install ipysheet
 ```
 
 If you have notebook 5.2 or below, you also need to execute:


### PR DESCRIPTION
A quick README fix for the JupyterLab extension installation command.