### PR TITLE
Fix tsconfig

### DIFF
--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -2,12 +2,13 @@
 "compilerOptions": {
     "resolveJsonModule": true,
     "noImplicitAny": false,
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
+    "lib": ["dom", "es2015"],
     "strictNullChecks": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2015",
     "outDir": "lib",
+    "rootDir": "src",
     "skipLibCheck": true,
     "strictNullChecks": false,
     "inlineSourceMap": true


### PR DESCRIPTION
Adding the rootDir option means that the output files will be in `lib/` instead of `lib/src`. I also removed the redundant lib settings, given that we now have an es2105 target.