### PR TITLE
Fix embedding

### DIFF
--- a/js/karma.conf.js
+++ b/js/karma.conf.js
@@ -29,8 +29,7 @@ module.exports = function (config) {
             mode: 'development',
             resolve: {
                 extensions: ['.js'],
-                alias: {'ipysheet$': path.resolve(__dirname, './lib/ipysheet')}
-
+                alias: {ipysheet$: path.resolve(__dirname, './lib/index')}
             },
         },
         reporters: ['progress', 'mocha'],

--- a/js/karma.conf.js
+++ b/js/karma.conf.js
@@ -29,6 +29,8 @@ module.exports = function (config) {
             mode: 'development',
             resolve: {
                 extensions: ['.js'],
+                alias: {'ipysheet$': path.resolve(__dirname, './lib/ipysheet')}
+
             },
         },
         reporters: ['progress', 'mocha'],

--- a/js/package.json
+++ b/js/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.2",
   "description": "Spreadsheet in the Jupyter notebook",
   "author": "Maarten A. Breddels",
-  "main": "lib/src/index.js",
+  "main": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/QuantStack/ipysheet.git"

--- a/js/src/embed.ts
+++ b/js/src/embed.ts
@@ -7,3 +7,5 @@
 // Export widget models and views, and the npm package version number.
 export * from './sheet';
 export {version} from './version';
+import * as Handsontable from 'handsontable';
+export { Handsontable };

--- a/js/src/extension.ts
+++ b/js/src/extension.ts
@@ -8,7 +8,6 @@ if (window['require'] !== undefined) {
         map: {
             "*" : {
                 "ipysheet": "nbextensions/ipysheet/index",
-                "handsontable": "nbextensions/ipysheet/handsontable",
                 "jupyter-js-widgets": "nbextensions/jupyter-js-widgets/extension"
             }
         }

--- a/js/src/handsontable_mod.ts
+++ b/js/src/handsontable_mod.ts
@@ -1,4 +1,0 @@
-import * as Handsontable from 'handsontable';
-
-export default Handsontable;
-

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -10,3 +10,5 @@
 // Export widget models and views, and the npm package version number.
 export * from './sheet';
 export { version } from './version';
+import * as Handsontable from 'handsontable';
+export { Handsontable };

--- a/js/src/renderer.ts
+++ b/js/src/renderer.ts
@@ -2,7 +2,7 @@ import * as widgets  from '@jupyter-widgets/base';
 import {extend} from 'lodash';
 import {version, semver_range} from './version';
 // @ts-ignore
-import * as Handsontable from 'handsontable';
+import {Handsontable} from 'ipysheet';
 
 
 let RendererModel = widgets.WidgetModel.extend({

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = [
         module: {
             rules: rules
         },
-        externals: ['@jupyter-widgets/base', 'handsontable']
+        externals: ['@jupyter-widgets/base']
     },
     {
         // same for render
@@ -81,7 +81,7 @@ module.exports = [
         module: {
             rules: rules
         },
-        externals: ['@jupyter-widgets/base', 'handsontable']
+        externals: ['@jupyter-widgets/base', 'ipysheet']
     },
     {
         // Embeddable ipysheet bundle
@@ -109,7 +109,7 @@ module.exports = [
         module: {
             rules: rules
         },
-        externals: ['@jupyter-widgets/base', 'handsontable']
+        externals: ['@jupyter-widgets/base']
     },
     {
         // same for renderer
@@ -124,17 +124,6 @@ module.exports = [
         module: {
             rules: rules
         },
-        externals: ['@jupyter-widgets/base', 'handsontable']
+        externals: ['@jupyter-widgets/base', 'ipysheet']
     },
-    {
-        entry: './node_modules/handsontable/dist/handsontable.min.js',
-        output: {
-            filename: 'handsontable.js',
-            path: path.resolve(__dirname, '../ipysheet/static'),
-            libraryTarget: 'amd'
-        },
-        module: {
-            rules: rules
-        },
-    }
 ];

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,7 @@ class NPM(Command):
         os.path.join(here, 'ipysheet', 'static', 'extension.js'),
         os.path.join(here, 'ipysheet', 'static', 'index.js'),
         os.path.join(here, 'ipysheet', 'static', 'extension-renderer.js'),
-        os.path.join(here, 'ipysheet', 'static', 'renderer.js'),
-        os.path.join(here, 'ipysheet', 'static', 'handsontable.js')
+        os.path.join(here, 'ipysheet', 'static', 'renderer.js')
     ]
 
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,6 @@ setup_args = {
     'include_package_data': True,
     'data_files': [
         ('share/jupyter/nbextensions/ipysheet', [
-            'ipysheet/static/handsontable.js',
             'ipysheet/static/extension.js',
             'ipysheet/static/index.js',
             'ipysheet/static/index.js.map',


### PR DESCRIPTION
The issue was that the renderer defined handsontable as external, but could not get it in an embedding context. It is still a mystery why/how this worked before.

Instead of 'rebundling' handsontable, the renderer now depends on ipysheet to re-export Handsontable.

In order to make handsontable require ipysheet, we add ipysheet/index.js inside of the ipysheet project, such that files in ipysheet can import itself. Webpack than defines ipysheet external, so it is not packaged in the same bundle. It's a small hack, but pretty solid.