### PR TITLE
Improve JLab styling

### DIFF
--- a/js/css/custom.css
+++ b/js/css/custom.css
@@ -97,8 +97,8 @@
 
 .p-Widget .handsontable tbody th.ht__active_highlight,
 .p-Widget .handsontable thead th.ht__active_highlight {
-  background-color: var(--jp-brand-color3);
-  color: var(--jp-content-font-color0);
+  background-color: var(--jp-brand-color1);
+  color: white;
 }
 
 .p-Widget .handsontableInput {
@@ -118,8 +118,8 @@
 }
 
 .p-Widget .handsontable td.htSearchResult {
-  background: var(--jp-accent-color3);
-  color: var(--jp-content-font-color0);
+  background: var(--jp-accent-color1);
+  color: white;
 }
 
 .p-Widget .htBordered.htTopBorderSolid {


### PR DESCRIPTION
Use more coherent colors for selection:

Before:
![jlab_worse](https://user-images.githubusercontent.com/21197331/54541150-a6df8080-4999-11e9-9e93-8212164f937c.png)
After:
![jlab_better](https://user-images.githubusercontent.com/21197331/54541165-acd56180-4999-11e9-8221-5798dd13604c.png)

It makes it also more readable in dark mode