### PR TITLE
Fix cell metadata initialization for None cells

### DIFF
--- a/js/src/sheet.ts
+++ b/js/src/sheet.ts
@@ -110,9 +110,6 @@ let SheetModel = widgets.DOMWidgetModel.extend({
     },
     _cell_data_to_grid: function(cell) {
         let value = cell.get('value');
-        if((value === null) || (value === undefined)) {
-            return;
-        }
         for(let i = cell.get('row_start'); i <= cell.get('row_end'); i++) {
             for(let j = cell.get('column_start'); j <= cell.get('column_end'); j++) {
                 let value = cell.get('value');


### PR DESCRIPTION
When the cell value is None, the cell metadata (type, style...) is not set. Causing other issues.
This fixes #102