### PR TITLE
Use Image.from_file instead of Image.from_url in the example

### DIFF
--- a/examples/widget_cell.ipynb
+++ b/examples/widget_cell.ipynb
@@ -83,7 +83,7 @@
    "source": [
     "sheet = ipysheet.sheet()\n",
     "\n",
-    "column1 = ipysheet.column(0, [Image.from_url('./image.png') for _ in range(5)], style={'min-width': '60px', 'min-height': '50px'})\n",
+    "column1 = ipysheet.column(0, [Image.from_file('./image.png') for _ in range(5)], style={'min-width': '60px', 'min-height': '50px'})\n",
     "column2 = ipysheet.column(1, [1.] * 5)\n",
     "\n",
     "sheet"


### PR DESCRIPTION
Replace the use of `Image.from_url` by `Image.from_file` to make `widget_cell` example work in JupyterLab.

With `Image.from_url`:

![image](https://user-images.githubusercontent.com/591645/58751361-c6b51980-849d-11e9-826c-181b124c0c67.png)

With `Image.from_file`:

![image](https://user-images.githubusercontent.com/591645/58751366-ce74be00-849d-11e9-972a-9372b01e6dc6.png)
