### PR TITLE
WIP: Feat selections

### DIFF
--- a/ipysheet/sheet.py
+++ b/ipysheet/sheet.py
@@ -101,6 +101,8 @@ class Sheet(widgets.DOMWidget):
     column_resizing = Bool(True).tag(sync=True)
     row_resizing = Bool(True).tag(sync=True)
     search_token = Unicode('').tag(sync=True)
+    highlight_selected_rows = Bool(False).tag(sync=True)
+    highlight_selected_columns = Bool(False).tag(sync=True)
 
     layout = LayoutTraitType(kw=dict(height='auto', width='auto')).tag(sync=True, **widgets.widget_serialization)
 

--- a/js/css/custom.css
+++ b/js/css/custom.css
@@ -94,7 +94,7 @@
 .p-Widget .handsontable td.area-5:before,
 .p-Widget .handsontable td.area-6:before,
 .p-Widget .handsontable td.area-7:before {
-  background-color: var(--jp-brand-color2);
+  background-color: var(--jp-brand-color1);
 }
 
 .p-Widget .handsontable tbody th.ht__highlight,
@@ -162,6 +162,10 @@
 .p-Widget .handsontable .wtBorder.area {
   background-color: var(--jp-brand-color0) !important;
   border-color: var(--jp-layout-color0) !important;
+}
+
+.p-Widget .handsontable td.area::before {
+  opacity: .2;
 }
 
 /* Pikaday styling */

--- a/js/src/sheet.ts
+++ b/js/src/sheet.ts
@@ -285,6 +285,13 @@ let SheetView = widgets.DOMWidgetView.extend({
             this.model.on('change:column_headers change:row_headers', this._update_hot_settings, this);
             this.model.on('change:stretch_headers change:column_width', this._update_hot_settings, this);
             this.model.on('change:column_resizing change:row_resizing', this._update_hot_settings, this);
+            this.model.on('change:highlight_selected_rows change:highlight_selected_columns', () => {
+                [...this.hot.selection.highlight.headers.values()].forEach(highlight => {
+                    highlight.settings.highlightRowClassName = this.model.get('highlight_selected_rows')  ? 'area' : undefined;
+                    highlight.settings.highlightColumnClassName = this.model.get('highlight_selected_columns')  ? 'area' : undefined;
+                });
+                this.hot.render();
+            });
             this.model.on('change:search_token', this._search, this);
             this._search()
         });
@@ -404,7 +411,9 @@ let SheetView = widgets.DOMWidgetView.extend({
             stretchH: this.model.get('stretch_headers'),
             colWidths: this.model.get('column_width') || undefined,
             manualColumnResize: this.model.get('column_resizing'),
-            manualRowResize: this.model.get('row_resizing')
+            manualRowResize: this.model.get('row_resizing'),
+            currentRowClassName: this.model.get('highlight_selected_rows')    ? 'area' : undefined,
+            currentColClassName: this.model.get('highlight_selected_columns') ? 'area' : undefined
         };
     },
     _search: function(render=true, ignore_empty_string=false) {


### PR DESCRIPTION
WIP to allow users to select rows or columns.
Only includes the styling of the selection:
![image](https://user-images.githubusercontent.com/1765949/65522769-8c0f3b00-deeb-11e9-947c-d30918b57142.png)

Inspired by https://stackoverflow.com/questions/30857341/restricting-selection-to-entire-row-column-in-handsontable

TODO: propagate selected rows, selected columns and/or selected areas.