### PR TITLE
Update doc link to stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Spreadsheet in the Jupyter notebook:
 
    * Try it out using binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/ipysheet/stable?filepath=docs%2Fsource%2Findex.ipynb)
-   * Or check out the documentation at https://ipysheet.readthedocs.io/
+   * Or check out the documentation at [https://ipysheet.readthedocs.io/](https://ipysheet.readthedocs.io/en/stable/)
 
 **Create a table and drive a value using ipywidgets:**
 


### PR DESCRIPTION
Brought up in https://github.com/QuantStack/ipysheet/issues/211
Since the `latest` version of the documentation is broken, I suggest to change the link in the README to the `stable` version.
