### PR TITLE
Include the dist/ files in the npm package so they can be served from CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,.js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,.js,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "dist/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf,js.LICENSE.txt}"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Fixes #230. This is a simple fix, but should get this working on Voila, Databricks, possibly Colab, etc., that depend on the CDN-served assets.

CC @martinRenou 