### PR TITLE
Removed jupyter_server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup_args = dict(
     packages=setuptools.find_packages(),
     cmdclass=cmdclass,
     install_requires=[
-        "jupyter_server>=1.6,<2",
         "ipywidgets>=7.5.0,<9.0",
     ],
     zip_safe=False,


### PR DESCRIPTION
This PR removes `jupyter_server` from the dependency list as it is not being used anywhere in the source code. This can potentially make ipysheet compatible with JupyterLite https://github.com/QuantStack/ipysheet/issues/239