### PR TITLE
Don't force a datatype on widget values

### DIFF
--- a/ipysheet/pandas_loader.py
+++ b/ipysheet/pandas_loader.py
@@ -83,7 +83,7 @@ def _extract_column(data, idx):
 
         return np.array(d, dtype='M')
     elif type == 'widget':
-        return np.array([wid.value for wid in arr], dtype='f')
+        return np.array([wid.value for wid in arr])
     else:
         return np.array(arr)
 


### PR DESCRIPTION
Exporting a sheet back to a Pandas dataframe will fail if the cell is represented through a custom ipywidget, if the data type of the underlying value is not float.

For example, when creating a sheet that has a column as such:
```python
sample_sheet = sheet(columns=1)

sample_col = column(0, [
    widgets.Dropdown(
        options=["WARN", "DROP", "FAIL", ""],
        value="WARN"
    )
])

df = to_dataframe(sample_sheet)
```

You'll get the following stack trace:

> ---------------------------------------------------------------------------
> ValueError                                Traceback (most recent call last)
> Cell In[8], line 10
>       1 sample_sheet = sheet(columns=1, rows=1)
>       3 sample_col = column(0, [
>       4     widgets.Dropdown(
>       5         options=["WARN", "DROP", "FAIL", ""],
>       6         value="WARN"
>       7     )
>       8 ])
> ---> 10 df = to_dataframe(sample_sheet)
> 
> File [~/Source/sample/.venv/lib/python3.11/site-packages/ipysheet/pandas_loader.py:128](https://file+.vscode-resource.vscode-cdn.net/home/dev/Source/sample/~/Source/sample/.venv/lib/python3.11/site-packages/ipysheet/pandas_loader.py:128), in to_dataframe(sheet)
>     124 else:
>     125     row_headers = list(sheet.row_headers)
>     127 return pd.DataFrame(
> --> 128     {
>     129         header: _extract_column(data, idx)
>     130         for idx, header in enumerate(column_headers)
>     131     },
>     132     index=row_headers,
>     133     columns=column_headers
>     134 )
> 
> File [~/Source/sample/.venv/lib/python3.11/site-packages/ipysheet/pandas_loader.py:129](https://file+.vscode-resource.vscode-cdn.net/home/dev/Source/sample/~/Source/sample/.venv/lib/python3.11/site-packages/ipysheet/pandas_loader.py:129), in (.0)
>     124 else:
>     125     row_headers = list(sheet.row_headers)
>     127 return pd.DataFrame(
>     128     {
> --> 129         header: _extract_column(data, idx)
>     130         for idx, header in enumerate(column_headers)
>     131     },
>     132     index=row_headers,
>     133     columns=column_headers
>     134 )
> 
> File [~/Source/sample/.venv/lib/python3.11/site-packages/ipysheet/pandas_loader.py:86](https://file+.vscode-resource.vscode-cdn.net/home/dev/Source/sample/~/Source/sample/.venv/lib/python3.11/site-packages/ipysheet/pandas_loader.py:86), in _extract_column(data, idx)
>      84     return np.array(d, dtype='M')
>      85 elif type == 'widget':
> ---> 86     return np.array([wid.value for wid in arr], **_dtype='f'_**)
>      87 else:
>      88     return np.array(arr)
> 
> ValueError: could not convert string to float: 'WARN'


This commit removes the explicit dtype.