### PR TITLE
Update README.md to new handsontable url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # WARNING
 
-Due to [Handsontable licensing changes](https://handsontable.com/blog/articles/2019/3/handsontable-drops-open-source-for-a-non-commercial-license) ipysheet is stuck witch the outdated Handsontable version 6.2.2 (open-source).
+Due to [Handsontable licensing changes](https://handsontable.com/blog/handsontable-drops-open-source-for-a-non-commercial-license) ipysheet is stuck witch the outdated Handsontable version 6.2.2 (open-source).
 We recommend not using ipysheet anymore. We suggest an alternative like [ipydatagrid](https://github.com/bloomberg/ipydatagrid).
 
 Spreadsheet in the Jupyter notebook:


### PR DESCRIPTION
I came to the repo - saw the news to use ipydatagrid, I went to the blog post for handsontable linked in the readme and it did not work.

Not sure this matters as you noted, but thought it might be nice to direct people to the updated url.